### PR TITLE
Library workspace management

### DIFF
--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/AppPlatform.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/AppPlatform.java
@@ -43,6 +43,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 
@@ -95,7 +97,7 @@ public class AppPlatform {
     throws IOException {
         if (EditorPlatform.isAssertionEnabled()) {
             // Development mode : we do not delegate to the existing instance
-            notificationHandler.handleLaunch(parameters.getUnnamed());
+            notificationHandler.handleLaunch(parameters.getUnnamed(), parameters.getNamed());
             return true;
         } else {
             return requestStartGeneric(notificationHandler, parameters);
@@ -103,7 +105,7 @@ public class AppPlatform {
     }
     
     public interface AppNotificationHandler {
-        public void handleLaunch(List<String> files);
+        public void handleLaunch(List<String> files, Map<String, String> namedParameters);
         public void handleOpenFilesAction(List<String> files);
         public void handleMessageBoxFailure(Exception x);
         public void handleQuitAction();
@@ -130,7 +132,7 @@ public class AppPlatform {
         final boolean result;
         messageBox = new MessageBox<>(getMessageBoxFolder(), MessageBoxMessage.class, 1000 /* ms */);
         if (messageBox.grab(new MessageBoxDelegate(notificationHandler))) {
-            notificationHandler.handleLaunch(parameters.getUnnamed());
+            notificationHandler.handleLaunch(parameters.getUnnamed(), parameters.getNamed());
             result = true;
         } else {
             result = false;

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
@@ -1354,6 +1354,8 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
                             fxmlPath.toFile());
             });
             libraryDialogController.setOnAddFolder(() -> onImportFromFolder(libraryDialogController.getStage()));
+            libraryDialogController.setOnLinkFolder(() -> onLinkFolderToWorkspace(libraryDialogController.getStage()));
+            libraryDialogController.setOnLinkJar(() -> onLinkJarToWorkspace(libraryDialogController.getStage()));
         }
 
         libraryDialogController.openWindow();
@@ -1365,6 +1367,14 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     
     public void onImportFromFolder(Window owner) {
         libraryPanelController.performImportFromFolder(owner);
+    }
+    
+    public void onLinkJarToWorkspace(Window owner) {
+        libraryPanelController.performLinkJarToWorkspace(owner);
+    }
+    
+    public void onLinkFolderToWorkspace(Window owner) {
+        libraryPanelController.performLinkFolderToWorkspace(owner);
     }
     
     @FXML
@@ -1408,6 +1418,15 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
             List<FXOMObject> selection = new ArrayList<>(osg.getItems());
             libraryPanelController.performImportSelection(selection);
         }
+    }
+    
+    @FXML
+    void onLibraryRefresh(ActionEvent event) {
+        
+        UserLibrary userLibrary = SceneBuilderApp.getSingleton().getUserLibrary();
+        
+        userLibrary.stopWatching();
+        userLibrary.startWatching();
     }
     
     @FXML
@@ -2129,9 +2148,24 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
             closeConfirmed = true;
         }
         
+        SceneBuilderApp app = SceneBuilderApp.getSingleton();
+        
+        if (closeConfirmed) {
+            // check if this is the last window with a non empty document: in that case, we reopen a new empty window after closing this
+            if (app.isLastWindowOpened()) {
+                
+                if (getEditorController().getFxomDocument().getSceneGraphRoot() != null) {
+                    
+                    DocumentWindowController newWindow = app.makeNewWindow();
+                    newWindow.updateWithDefaultContent();
+                    newWindow.openWindow();
+                }
+            }
+        }
+        
         // Closes if confirmed
         if (closeConfirmed) {
-            SceneBuilderApp.getSingleton().documentWindowRequestClose(this);
+            app.documentWindowRequestClose(this);
             
             // Write java preferences at close time
             updatePreferences();

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2019 Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -33,7 +33,6 @@
 package com.oracle.javafx.scenebuilder.app;
 
 import com.oracle.javafx.scenebuilder.app.i18n.I18N;
-import com.oracle.javafx.scenebuilder.app.info.InfoPanelController;
 import com.oracle.javafx.scenebuilder.app.menubar.MenuBarController;
 import com.oracle.javafx.scenebuilder.app.message.MessageBarController;
 import com.oracle.javafx.scenebuilder.app.preferences.PreferencesController;
@@ -52,6 +51,7 @@ import com.oracle.javafx.scenebuilder.kit.editor.panel.content.ContentPanelContr
 import com.oracle.javafx.scenebuilder.kit.editor.panel.css.CssPanelController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.AbstractHierarchyPanelController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.AbstractHierarchyPanelController.DisplayOption;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.info.InfoPanelController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.HierarchyPanelController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.inspector.InspectorPanelController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.inspector.InspectorPanelController.SectionId;
@@ -81,6 +81,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -91,6 +92,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
@@ -240,6 +242,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     
     private FileTime loadFileTime;
     private Job saveJob;
+    private PreferencesRecordGlobal recordGlobal;
 
     private final EventHandler<KeyEvent> mainKeyEventFilter = event -> {
         //------------------------------------------------------------------
@@ -260,8 +263,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
         //
         final Node focusOwner = getScene().getFocusOwner();
         final KeyCombination accelerator = getAccelerator(event);
-        if (isTextInputControlEditing(focusOwner) == true 
-                && accelerator != null) {
+        if (isTextInputControlEditing(focusOwner) && accelerator != null) {
 
 //            focusOwner.getInputMap()
 //                      .lookupMapping(KeyBinding.toKeyBinding(event))
@@ -289,7 +291,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
             // Consume the event so the control action is not performed natively.
             event.consume();
             // When using system menu bar, the control action is performed by the app.
-            if (menuBarController.getMenuBar().isUseSystemMenuBar() == false) {
+            if (!menuBarController.getMenuBar().isUseSystemMenuBar()) {
                 if (canPerformControlAction(DocumentControlAction.SELECT_ALL)) {
                     performControlAction(DocumentControlAction.SELECT_ALL);
                 }
@@ -299,7 +301,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
         // MenuItems define a single accelerator.
         // BACK_SPACE key must be handled same way as DELETE key.
         boolean isBackspace = KeyCode.BACK_SPACE.equals(event.getCode());
-        if (isTextInputControlEditing(focusOwner) == false && isBackspace) {
+        if (!isTextInputControlEditing(focusOwner) && isBackspace) {
             if (canPerformEditAction(DocumentEditAction.DELETE)) {
                 performEditAction(DocumentEditAction.DELETE);
             }
@@ -429,9 +431,10 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     }
     
     public String getFxmlText() {
-        return editorController.getFxmlText();
+        var recordGlobal = getPreferencesRecordGlobal();
+        return editorController.getFxmlText(recordGlobal.isWildcardImports());
     }
-    
+
     public void refreshLibraryDisplayOption(LibraryPanelController.DISPLAY_MODE option) {
         switch (option) {
             case LIST:
@@ -726,8 +729,8 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
                     documentSplitController.hideTarget();
                     leftSplitController.hideTarget();
                 } else {
-                    assert librarySplitController.isTargetVisible() == false
-                            && documentSplitController.isTargetVisible() == false;
+                    assert !librarySplitController.isTargetVisible()
+                            && !documentSplitController.isTargetVisible();
                     // Show Left => show both Library + Document
                     librarySplitController.showTarget();
                     documentSplitController.showTarget();
@@ -772,11 +775,11 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
                 if (librarySplitController.isTargetVisible()) {
                     assert leftSplitController.isTargetVisible();
                     librarySplitController.hideTarget();
-                    if (documentSplitController.isTargetVisible() == false) {
+                    if (!documentSplitController.isTargetVisible()) {
                         leftSplitController.hideTarget();
                     }
                 } else {
-                    if (leftSplitController.isTargetVisible() == false) {
+                    if (!leftSplitController.isTargetVisible()) {
                         leftSplitController.showTarget();
                     }
                     librarySplitController.showTarget();
@@ -790,11 +793,11 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
                 if (documentSplitController.isTargetVisible()) {
                     assert leftSplitController.isTargetVisible();
                     documentSplitController.hideTarget();
-                    if (librarySplitController.isTargetVisible() == false) {
+                    if (!librarySplitController.isTargetVisible()) {
                         leftSplitController.hideTarget();
                     }
                 } else {
-                    if (leftSplitController.isTargetVisible() == false) {
+                    if (!leftSplitController.isTargetVisible()) {
                         leftSplitController.showTarget();
                     }
                     documentSplitController.showTarget();
@@ -971,7 +974,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
         
         final FXOMDocument fxomDocument = editorController.getFxomDocument();
         final boolean noFxmlText = (fxomDocument == null) || (fxomDocument.getFxomRoot() == null);
-        final boolean clean = isDocumentDirty() == false;
+        final boolean clean = !isDocumentDirty();
         final boolean noName = (fxomDocument != null) && (fxomDocument.getLocation() == null);
         
         return noFxmlText && clean && noName;
@@ -1028,7 +1031,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
         final PreferencesRecordGlobal recordGlobal = pc.getRecordGlobal();
         // recentItems may not contain the current document
         // if the Open Recent -> Clear menu has been invoked
-        if (recordGlobal.containsRecentItem(fxmlLocation) == false) {
+        if (!recordGlobal.containsRecentItem(fxmlLocation)) {
             recordGlobal.addRecentItem(fxmlLocation);
         }
     }
@@ -1055,7 +1058,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
         assert libraryDocumentSplitPane != null;
         assert libraryDocumentSplitPane.getItems().size() == 2;
         assert documentAccordion != null;
-        assert documentAccordion.getPanes().isEmpty() == false;
+        assert !documentAccordion.getPanes().isEmpty();
         assert libraryViewAsList != null;
         assert libraryViewAsSections != null;
         assert libraryReveal != null;
@@ -1163,12 +1166,12 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     @Override
     public void openWindow() {
         
-        if (getStage().isShowing() == false) {
+        if (!getStage().isShowing()) {
             // Starts watching document:
             //      - editorController watches files referenced from the FXML text
             //      - watchingController watches the document file, i18n resources, 
             //        preview stylesheets...
-            assert editorController.isFileWatchingStarted() == false;
+            assert !editorController.isFileWatchingStarted();
             editorController.startFileWatching();
             watchingController.start();
         }
@@ -1332,8 +1335,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
 
     private void updateHierarchyDisplayOption() {
         // Update preferences
-        final PreferencesController preferencesController = PreferencesController.getSingleton();
-        final PreferencesRecordGlobal recordGlobal = preferencesController.getRecordGlobal();
+        var recordGlobal = getPreferencesRecordGlobal();
         recordGlobal.updateHierarchyDisplayOption(hierarchyPanelController.getDisplayOption());
     }
 
@@ -1401,8 +1403,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
 
     private void updateLibraryDisplayOption() {
         // Update preferences
-        final PreferencesController preferencesController = PreferencesController.getSingleton();
-        final PreferencesRecordGlobal recordGlobal = preferencesController.getRecordGlobal();
+        var recordGlobal = getPreferencesRecordGlobal();
         recordGlobal.updateLibraryDisplayOption(libraryPanelController.getDisplayMode());
     }
 
@@ -1414,7 +1415,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
 
         if (asg instanceof ObjectSelectionGroup) {
             ObjectSelectionGroup osg = (ObjectSelectionGroup)asg;
-            assert osg.getItems().isEmpty() == false;
+            assert !osg.getItems().isEmpty();
             List<FXOMObject> selection = new ArrayList<>(osg.getItems());
             libraryPanelController.performImportSelection(selection);
         }
@@ -1495,7 +1496,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
             return false;
         } else if (isTextInputControlEditing(focusOwner)) {
             final TextInputControl tic = getTextInputControl(focusOwner);
-            result = tic.getSelectedText() != null && tic.getSelectedText().isEmpty() == false;
+            result = tic.getSelectedText() != null && !tic.getSelectedText().isEmpty();
         } else {
             result = getEditorController().canPerformControlAction(ControlAction.SELECT_NONE);
         }
@@ -1519,7 +1520,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
             return false;
         } else if (isTextInputControlEditing(focusOwner)) {
             final TextInputControl tic = getTextInputControl(focusOwner);
-            result = tic.getSelectedText() != null && tic.getSelectedText().isEmpty() == false;
+            result = tic.getSelectedText() != null && !tic.getSelectedText().isEmpty();
         } else if (isCssRulesEditing(focusOwner) || isCssTextEditing(focusOwner)) {
             result = true;
         } else {
@@ -1550,7 +1551,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
             return false;
         } else if (isTextInputControlEditing(focusOwner)) {
             final TextInputControl tic = getTextInputControl(focusOwner);
-            result = tic.getSelectedText() != null && tic.getSelectedText().isEmpty() == false;
+            result = tic.getSelectedText() != null && !tic.getSelectedText().isEmpty();
         } else {
             result = getEditorController().canPerformEditAction(EditAction.CUT);
         }
@@ -1660,15 +1661,20 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     }
 
     private void performImportFxml() {
+        fetchFXMLFile().ifPresent(fxmlFile -> getEditorController().performImportFxml(fxmlFile));
+    }
 
-        final FileChooser fileChooser = new FileChooser();
-        final ExtensionFilter f
-                = new ExtensionFilter(I18N.getString("file.filter.label.fxml"),
-                        "*.fxml"); //NOI18N
+    private void performIncludeFxml() {
+        fetchFXMLFile().ifPresent(fxmlFile -> getEditorController().performIncludeFxml(fxmlFile));
+    }
+
+    private Optional<File> fetchFXMLFile() {
+        var fileChooser = new FileChooser();
+        var f = new ExtensionFilter(I18N.getString("file.filter.label.fxml"), "*.fxml"); //NOI18N
         fileChooser.getExtensionFilters().add(f);
         fileChooser.setInitialDirectory(EditorController.getNextInitialDirectory());
 
-        File fxmlFile = fileChooser.showOpenDialog(getStage());
+        var fxmlFile = fileChooser.showOpenDialog(getStage());
         if (fxmlFile != null) {
             // See DTL-5948: on Linux we anticipate an extension less path.
             final String path = fxmlFile.getPath();
@@ -1678,9 +1684,8 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
 
             // Keep track of the user choice for next time
             EditorController.updateNextInitialDirectory(fxmlFile);
-
-            this.getEditorController().performImportFxml(fxmlFile);
         }
+        return Optional.ofNullable(fxmlFile);
     }
 
     private void performImportMedia() {
@@ -1698,7 +1703,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
         final ExtensionFilter mediaFilter
                 = new ExtensionFilter(I18N.getString("file.filter.label.media"),
                         ResourceUtils.getSupportedMediaExtensions());
-        
+
         fileChooser.getExtensionFilters().add(mediaFilter);
         fileChooser.getExtensionFilters().add(imageFilter);
         fileChooser.getExtensionFilters().add(audioFilter);
@@ -1708,35 +1713,11 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
 
         File mediaFile = fileChooser.showOpenDialog(getStage());
         if (mediaFile != null) {
-            
+
             // Keep track of the user choice for next time
             EditorController.updateNextInitialDirectory(mediaFile);
 
             this.getEditorController().performImportMedia(mediaFile);
-        }
-    }
-
-    private void performIncludeFxml() {
-
-        final FileChooser fileChooser = new FileChooser();
-        final ExtensionFilter f
-                = new ExtensionFilter(I18N.getString("file.filter.label.fxml"),
-                        "*.fxml"); //NOI18N
-        fileChooser.getExtensionFilters().add(f);
-        fileChooser.setInitialDirectory(EditorController.getNextInitialDirectory());
-
-        File fxmlFile = fileChooser.showOpenDialog(getStage());
-        if (fxmlFile != null) {
-            // See DTL-5948: on Linux we anticipate an extension less path.
-            final String path = fxmlFile.getPath();
-            if (!path.endsWith(".fxml")) { //NOI18N
-                fxmlFile = new File(path + ".fxml"); //NOI18N
-            }
-
-            // Keep track of the user choice for next time
-            EditorController.updateNextInitialDirectory(fxmlFile);
-
-            this.getEditorController().performIncludeFxml(fxmlFile);
         }
     }
 
@@ -1885,7 +1866,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     
     private void performGoToSection(SectionId sectionId) {
         // First make the right panel visible if not already the case
-        if (isRightPanelVisible() == false) {
+        if (!isRightPanelVisible()) {
             performControlAction(DocumentControlAction.TOGGLE_RIGHT_PANEL);
         }
         inspectorPanelController.setExpandedSection(sectionId);
@@ -1925,7 +1906,8 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
                 if (saveConfirmed) {
                     try {
                         watchingController.removeDocumentTarget();
-                        final byte[] fxmlBytes = editorController.getFxmlText().getBytes("UTF-8"); //NOI18N
+                        var recordGlobal = getPreferencesRecordGlobal();
+                        final byte[] fxmlBytes = editorController.getFxmlText(recordGlobal.isWildcardImports()).getBytes(StandardCharsets.UTF_8); //NOI18N
                         Files.write(fxmlPath, fxmlBytes);
                         updateLoadFileTime();
                         watchingController.update();
@@ -2063,8 +2045,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
                     EditorController.updateNextInitialDirectory(fxmlFile);
 
                     // Update recent items with just saved file
-                    final PreferencesController pc = PreferencesController.getSingleton();
-                    final PreferencesRecordGlobal recordGlobal = pc.getRecordGlobal();
+                    var recordGlobal = getPreferencesRecordGlobal();
                     recordGlobal.addRecentItem(fxmlFile);
                 }
             }
@@ -2109,7 +2090,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
         // Check if an editing session is on going
         if (getEditorController().isTextEditingSessionOnGoing()) {
             // Check if we can commit the editing session
-            if (getEditorController().canGetFxmlText() == false) {
+            if (!getEditorController().canGetFxmlText()) {
                 // Commit failed
                 return ActionStatus.CANCELLED;
             }
@@ -2269,6 +2250,14 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
             errorDialog.setDebugInfoWithThrowable(ioe);
             errorDialog.showAndWait();
         }
+    }
+
+    private PreferencesRecordGlobal getPreferencesRecordGlobal() {
+        if (recordGlobal == null) {
+            final PreferencesController preferencesController = PreferencesController.getSingleton();
+            recordGlobal = preferencesController.getRecordGlobal();
+        }
+        return recordGlobal;
     }
 }
 

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/SceneBuilderApp.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/SceneBuilderApp.java
@@ -58,11 +58,14 @@ import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AlertDialog;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.ErrorDialog;
 import com.oracle.javafx.scenebuilder.kit.library.BuiltinLibrary;
 import com.oracle.javafx.scenebuilder.kit.library.user.UserLibrary;
+import com.oracle.javafx.scenebuilder.kit.library.user.ws.UserLibraryWorkspace;
 import com.oracle.javafx.scenebuilder.kit.metadata.Metadata;
 import com.oracle.javafx.scenebuilder.kit.util.control.effectpicker.EffectPicker;
+import com.thoughtworks.xstream.XStreamException;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -380,7 +383,7 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
      * AppPlatform.AppNotificationHandler
      */
     @Override
-    public void handleLaunch(List<String> files) {
+    public void handleLaunch(List<String> files, Map<String, String> namedParameters) {
         boolean showWelcomeDialog = files.isEmpty();
 
         setApplicationUncaughtExceptionHandler();
@@ -423,6 +426,18 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
 
         userLibrary.explorationCountProperty().addListener((ChangeListener<Number>) (ov, t, t1) -> userLibraryExplorationCountDidChange());
 
+        String workspaceXmlPath = namedParameters.get("ws");
+        if (workspaceXmlPath != null && !workspaceXmlPath.isEmpty()) {
+            
+            try {
+                UserLibraryWorkspace workspace = UserLibraryWorkspace.fromXml(Paths.get(workspaceXmlPath).toUri().toURL());
+                userLibrary.setUserWorkspace(workspace);
+            }
+            catch (MalformedURLException | XStreamException e) {
+                Logger.getLogger(SceneBuilderApp.class.getName()).log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+        
         userLibrary.startWatching();
 
         sendTrackingStartupInfo();
@@ -553,6 +568,10 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
             logTimestamp(ACTION.STOP);
             Platform.exit();
         }
+    }
+    
+    public boolean isLastWindowOpened() {
+        return windowList.size() == 1;
     }
 
     /**

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/preferences/PreferencesRecordGlobal.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/preferences/PreferencesRecordGlobal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -97,6 +97,7 @@ public class PreferencesRecordGlobal extends PreferencesRecordGlobalBase {
 
     static final int DEFAULT_RECENT_ITEMS_SIZE = 15;
     static final boolean DEFAULT_ACCORDION_ANIMATION = true;
+    static final boolean DEFAULT_WILDCARD_IMPORTS = false;
 
     /***************************************************************************
      *                                                                         *
@@ -111,6 +112,7 @@ public class PreferencesRecordGlobal extends PreferencesRecordGlobalBase {
     private boolean cssTableColumnsOrderingReversed = DEFAULT_CSS_TABLE_COLUMNS_ORDERING_REVERSED;
     private int recentItemsSize = DEFAULT_RECENT_ITEMS_SIZE;
     private boolean accordionAnimation = DEFAULT_ACCORDION_ANIMATION;
+    private boolean wildcardImports = DEFAULT_WILDCARD_IMPORTS;
     private final List<String> recentItems = new ArrayList<>();
 
     private LocalDate showUpdateDialogDate = null;
@@ -372,6 +374,14 @@ public class PreferencesRecordGlobal extends PreferencesRecordGlobalBase {
         this.accordionAnimation = accordionAnimation;
     }
 
+    public boolean isWildcardImports() {
+        return wildcardImports;
+    }
+
+    public void setWildcardImports(boolean wildcardImports) {
+        this.wildcardImports = wildcardImports;
+    }
+
     /**
      * Read data from the java preferences DB and initialize properties.
      */
@@ -454,7 +464,10 @@ public class PreferencesRecordGlobal extends PreferencesRecordGlobalBase {
         }
 
         // Accordion animation
-        setAccordionAnimation(applicationRootPreferences.getBoolean(ACCORDION_ANIMATION, true));
+        setAccordionAnimation(applicationRootPreferences.getBoolean(ACCORDION_ANIMATION, DEFAULT_ACCORDION_ANIMATION));
+
+        // Wildcard imports
+        setWildcardImports(applicationRootPreferences.getBoolean(WILDCARD_IMPORT, DEFAULT_WILDCARD_IMPORTS));
 
     }
 
@@ -518,6 +531,9 @@ public class PreferencesRecordGlobal extends PreferencesRecordGlobalBase {
                 break;
             case ACCORDION_ANIMATION:
                 applicationRootPreferences.putBoolean(ACCORDION_ANIMATION, isAccordionAnimation());
+                break;
+            case WILDCARD_IMPORT:
+                applicationRootPreferences.putBoolean(WILDCARD_IMPORT, isWildcardImports());
                 break;
             default:
                 super.writeToJavaPreferences(key);

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/preferences/PreferencesWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/preferences/PreferencesWindowController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -52,6 +52,7 @@ import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesControll
 import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesController.RECENT_ITEMS;
 import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesController.RECENT_ITEMS_SIZE;
 import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesController.TOOL_THEME;
+import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesController.WILDCARD_IMPORT;
 
 import static com.oracle.javafx.scenebuilder.kit.preferences.PreferencesRecordGlobalBase.DEFAULT_ALIGNMENT_GUIDES_COLOR;
 import static com.oracle.javafx.scenebuilder.kit.preferences.PreferencesRecordGlobalBase.DEFAULT_BACKGROUND_IMAGE;
@@ -67,6 +68,7 @@ import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordGl
 import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordGlobal.DEFAULT_ROOT_CONTAINER_HEIGHT;
 import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordGlobal.DEFAULT_ROOT_CONTAINER_WIDTH;
 import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordGlobal.DEFAULT_ACCORDION_ANIMATION;
+import static com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordGlobal.DEFAULT_WILDCARD_IMPORTS;
 
 import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.AbstractHierarchyPanelController.DisplayOption;
@@ -135,6 +137,8 @@ public class PreferencesWindowController extends AbstractFxmlWindowController {
     private ChoiceBox<EditorPlatform.GluonSwatch> gluonSwatch;
     @FXML
     private CheckBox animateAccordion;
+    @FXML
+    private CheckBox wildcardImports;
 
     private PaintPicker alignmentColorPicker;
     private PaintPicker parentRingColorPicker;
@@ -251,6 +255,10 @@ public class PreferencesWindowController extends AbstractFxmlWindowController {
         // Accordion Animation
         animateAccordion.setSelected(recordGlobal.isAccordionAnimation());
         animateAccordion.selectedProperty().addListener(new AnimationListener());
+
+        // Wildcard Imports
+        wildcardImports.setSelected(recordGlobal.isWildcardImports());
+        wildcardImports.selectedProperty().addListener(new WildcardImportListener());
     }
 
     /*
@@ -318,6 +326,9 @@ public class PreferencesWindowController extends AbstractFxmlWindowController {
 
         // Default Accordion Animation
         animateAccordion.setSelected(DEFAULT_ACCORDION_ANIMATION);
+
+        // Default Wildcard import
+        wildcardImports.setSelected(DEFAULT_WILDCARD_IMPORTS);
     }
 
     /**
@@ -549,6 +560,20 @@ public class PreferencesWindowController extends AbstractFxmlWindowController {
             recordGlobal.writeToJavaPreferences(ACCORDION_ANIMATION);
             // Update UI
             SceneBuilderApp.applyToAllDocumentWindows(dwc -> dwc.animateAccordion(newValue));
+        }
+    }
+
+    private static class WildcardImportListener implements ChangeListener<Boolean> {
+
+        @Override
+        public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
+            final PreferencesController preferencesController
+                    = PreferencesController.getSingleton();
+            final PreferencesRecordGlobal recordGlobal
+                    = preferencesController.getRecordGlobal();
+            // Update preferences
+            recordGlobal.setWildcardImports(newValue);
+            recordGlobal.writeToJavaPreferences(WILDCARD_IMPORT);
         }
     }
 }

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/DocumentWindow.fxml
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/DocumentWindow.fxml
@@ -75,6 +75,7 @@
                             <SeparatorMenuItem mnemonicParsing="false" />
                             <MenuItem mnemonicParsing="false" onAction="#onManageJarFxml" text="%library.panel.menu.manage.jar.fxml" />
                             <MenuItem fx:id="libraryImportSelection" mnemonicParsing="false" onAction="#onLibraryImportSelection" text="%library.panel.menu.import.selection" />
+                            <MenuItem mnemonicParsing="false" onAction="#onLibraryRefresh" text="%library.panel.menu.refresh" />
                             <SeparatorMenuItem mnemonicParsing="false" />
                             <Menu fx:id="customLibraryMenu" mnemonicParsing="false" text="%library.panel.menu.custom">
                               <items>

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
@@ -265,6 +265,7 @@ library = Library
 library.exploring = Exploring Library..
 library.panel.menu.manage.jar.fxml = JAR/FXML Manager
 library.panel.menu.import.selection = Import Selection
+library.panel.menu.refresh = Refresh Library
 # Messages below are temporarily unused
 #library.panel.menu.category.view = View Library Category
 #library.panel.menu.category.create = Create Library Category

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, 2018, Gluon and/or its affiliates.
+# Copyright (c) 2016, 2019, Gluon and/or its affiliates.
 # Copyright (c) 2012, 2014, Oracle and/or its affiliates.
 # All rights reserved. Use is subject to license terms.
 #
@@ -240,6 +240,7 @@ prefs.cssanalyzer.columns.defaults.first = "Defaults" Column First
 prefs.cssanalyzer.columns.defaults.last = "Defaults" Column Last
 prefs.recent.items = Recent items :
 prefs.animate.accordion = Animate Accordion :
+prefs.wildcard.import = Use Wildcard Imports :
 prefs.reset.default = Reset to Builtin Default Values
 prefs.document.theme = Default Theme :
 prefs.document.gluonswatch = Default Gluon Swatch :
@@ -364,19 +365,6 @@ message.bar.details = Click to access the list of warning messages
 # Message panel
 # -----------------------------------------------------------------------------
 message.panel.clear = Clear
-
-# -----------------------------------------------------------------------------
-# Info panel
-# -----------------------------------------------------------------------------
-info.label.assigned = Assigned fx:id
-info.label.component = Component
-info.label.use.fx.root = Use fx:root construct
-# Used after number 1
-info.label.item = item
-# Used after any number greater than 1
-info.label.items = items
-# The parameter is the name of a Java class
-info.tooltip.controller = Your Controller class must extend {0}
 
 # -----------------------------------------------------------------------------
 # Menu Bar

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp_ja.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp_ja.properties
@@ -240,7 +240,8 @@ prefs.cssanalyzer.columns.defaults.first = "デフォルト"列が最初
 prefs.cssanalyzer.columns.defaults.last = "デフォルト"列が最後
 prefs.recent.items = 最近のアイテム
 # TODO: translate
-prefs.animate.accordion = Animate Accordion
+prefs.animate.accordion = Animate Accordion :
+prefs.wildcard.import = Use Wildcard Imports :
 prefs.reset.default = 組込みデフォルト値に戻す
 prefs.document.theme = デフォルトのテーマ:
 prefs.document.gluonswatch = デフォルトのGluon Swatch :

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/preferences/Preferences.fxml
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/preferences/Preferences.fxml
@@ -123,9 +123,12 @@
     <Label text="%prefs.animate.accordion" GridPane.columnIndex="0" GridPane.rowIndex="17" />
     <CheckBox fx:id="animateAccordion" selected="true" GridPane.columnIndex="1" GridPane.rowIndex="17"/>
 
-    <Separator prefWidth="-1.0" GridPane.columnIndex="0" GridPane.columnSpan="2" GridPane.rowIndex="18" />
+    <Label text="%prefs.wildcard.import" GridPane.columnIndex="0" GridPane.rowIndex="18" />
+    <CheckBox fx:id="wildcardImports" selected="true" GridPane.columnIndex="1" GridPane.rowIndex="18"/>
 
-    <Button onAction="#resetToDefaultAction" prefWidth="-1.0" text="%prefs.reset.default" GridPane.columnIndex="0" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="19" />
+    <Separator prefWidth="-1.0" GridPane.columnIndex="0" GridPane.columnSpan="2" GridPane.rowIndex="19" />
+
+    <Button onAction="#resetToDefaultAction" prefWidth="-1.0" text="%prefs.reset.default" GridPane.columnIndex="0" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="20" />
   </children>
   <columnConstraints>
     <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="-Infinity" minWidth="-Infinity" />

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ subprojects {
         implementation 'org.eclipse.aether:aether-transport-http:1.1.0'
         implementation 'org.apache.maven:maven-aether-provider:3.3.9'
 
+        implementation 'com.thoughtworks.xstream:xstream:1.4.11.1' // to manage xml files for library-workspace
+
         implementation 'com.gluonhq:charm-glisten:5.0.0-jdk9'
 
         // REST API

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/EditorController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/EditorController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Gluon and/or its affiliates.
+ * Copyright (c) 2017, 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -120,7 +120,6 @@ import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.geometry.Bounds;
 import javafx.scene.Node;
-import javafx.scene.Parent;
 import javafx.scene.control.Control;
 import javafx.scene.effect.Effect;
 import javafx.scene.input.Clipboard;
@@ -347,8 +346,9 @@ public class EditorController {
      * Returns null or the fxml content being edited by this editor.
      * 
      * @return null or the fxml content being edited by this editor.
+     * @param wildcardImports If the FXML should have wildcards in its imports.
      */
-    public String getFxmlText() {
+    public String getFxmlText(boolean wildcardImports) {
         final String result;
         
         final FXOMDocument fxomDocument = getFxomDocument();
@@ -359,7 +359,7 @@ public class EditorController {
             if (sampleDataEnabled) {
                 fxomDocument.setSampleDataEnabled(false);
             }
-            result = fxomDocument.getFxmlText();
+            result = fxomDocument.getFxmlText(wildcardImports);
             if (sampleDataEnabled) {
                 fxomDocument.setSampleDataEnabled(true);
             }
@@ -543,7 +543,7 @@ public class EditorController {
 
     // -- Theme property
     private final ObjectProperty<Theme> themeProperty
-            = new SimpleObjectProperty<Theme>(EditorPlatform.DEFAULT_THEME) {
+            = new SimpleObjectProperty<>(EditorPlatform.DEFAULT_THEME) {
         @Override
         protected void invalidated() {
             FXOMDocument fxomDocument = getFxomDocument();

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
@@ -778,6 +778,10 @@ public class ContentPanelController extends AbstractFxmlPanelController
                     "log.warning.layout.failed", newLayoutException.getMessage());
         }
         
+        if (fxomDocument != null) {
+            fxomDocument.refreshSceneGraph();
+        }
+        
         if (isOutlinesVisible()) {
             updateOutlines();
         }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
@@ -63,6 +63,7 @@ import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.image.Image;
 import javafx.scene.input.InputEvent;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundImage;
@@ -904,6 +905,21 @@ public class ContentPanelController extends AbstractFxmlPanelController
         final ContextMenuController contextMenuController
                 = getEditorController().getContextMenuController();
         scrollPane.setContextMenu(contextMenuController.getContextMenu());
+        scrollPane.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
+            
+            if (e.getCode() == KeyCode.ESCAPE) {
+                // on ESC we select the parent of current selected item
+                Selection selection = getEditorController().getSelection();
+                FXOMObject parent = selection.getAncestor();
+                
+                if (parent != null) {
+                    selection.clear();
+                    selection.select(parent);
+                }
+                
+                e.consume();
+            }
+        });
         
         // Setup default workspace background
         setWorkspaceBackground(ImageUtils.getImage(getDefaultWorkspaceBackgroundURL()));

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/treeview/HierarchyTreeViewController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/treeview/HierarchyTreeViewController.java
@@ -46,11 +46,14 @@ import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.control.Cell;
 import javafx.scene.control.Control;
+import javafx.scene.control.MultipleSelectionModel;
 import javafx.scene.control.ScrollBar;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
+import javafx.scene.control.TableView.TableViewSelectionModel;
+import javafx.scene.input.KeyCode;
 
 /**
  * Hierarchy panel controller based on the TreeView control.
@@ -85,6 +88,22 @@ public class HierarchyTreeViewController extends AbstractHierarchyPanelControlle
         // We do not use the platform editing feature because 
         // editing is started on selection + simple click instead of double click
         treeView.setEditable(false);
+        
+        treeView.setOnKeyPressed(event -> {
+            // on ESC we select the parent of current selected item
+            if (event.getCode() == KeyCode.ESCAPE) {
+                
+                MultipleSelectionModel<TreeItem<HierarchyItem>> selectionModel = treeView.getSelectionModel();
+                TreeItem<HierarchyItem> item = selectionModel.getSelectedItem();
+                if (item != null) {
+                    TreeItem<HierarchyItem> parent = item.getParent();
+                    if (parent != null) {
+                        selectionModel.clearSelection();
+                        selectionModel.select(parent);
+                    }
+                }
+            }
+        });
     }
 
     @Override

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/info/IndexEntry.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/info/IndexEntry.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2016, 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -30,7 +31,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.oracle.javafx.scenebuilder.app.info;
+package com.oracle.javafx.scenebuilder.kit.editor.panel.info;
 
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
 import java.util.Objects;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/info/InfoPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/info/InfoPanelController.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2016, 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -29,9 +30,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.javafx.scenebuilder.app.info;
+package com.oracle.javafx.scenebuilder.kit.editor.panel.info;
 
-import com.oracle.javafx.scenebuilder.app.i18n.I18N;
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.editor.job.atomic.ModifyFxControllerJob;
 import com.oracle.javafx.scenebuilder.kit.editor.job.atomic.ToggleFxRootJob;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/info/LeftCell.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/info/LeftCell.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2016, 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -30,9 +31,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.oracle.javafx.scenebuilder.app.info;
+package com.oracle.javafx.scenebuilder.kit.editor.panel.info;
 
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.util.Callback;
@@ -40,7 +40,7 @@ import javafx.util.Callback;
 /**
  *
  */
-class RightCell extends TableCell<IndexEntry, FXOMObject> {
+class LeftCell extends TableCell<IndexEntry, String> {
     
     
     /*
@@ -48,35 +48,24 @@ class RightCell extends TableCell<IndexEntry, FXOMObject> {
      */
 
     @Override
-    protected void updateItem(FXOMObject rightValue, boolean empty) {
-        super.updateItem(rightValue, empty);
-        
-        final String text;
-        if (empty) {
-            text = ""; //NOI18N
-        } else {
-            if (rightValue == null) {
-                text = "null"; //NOI18N
-            } else {
-                text = rightValue.getGlueElement().getTagName();
-            }
-        }
-        setText(text);
+    protected void updateItem(String leftValue, boolean empty) {
+        super.updateItem(leftValue, empty);
+        setText(empty ? "" : leftValue); //NOI18N
     }
     
     
     
     
     public static class Factory 
-    implements Callback<TableColumn<IndexEntry, FXOMObject>, TableCell<IndexEntry, FXOMObject>> {
+    implements Callback<TableColumn<IndexEntry, String>, TableCell<IndexEntry, String>> {
 
         /*
-         * Callback<TableView<IndexEntry>, TableCell<IndexEntry, FXOMObject>>
+         * Callback<TableView<IndexEntry, String>, TableCell<IndexEntry, String>>
          */
 
         @Override
-        public TableCell<IndexEntry, FXOMObject> call(TableColumn<IndexEntry, FXOMObject> tc) {
-            return new RightCell();
+        public TableCell<IndexEntry, String> call(TableColumn<IndexEntry, String> tc) {
+            return new LeftCell();
         }
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/info/RightCell.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/info/RightCell.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2016, 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -30,8 +31,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.oracle.javafx.scenebuilder.app.info;
+package com.oracle.javafx.scenebuilder.kit.editor.panel.info;
 
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.util.Callback;
@@ -39,7 +41,7 @@ import javafx.util.Callback;
 /**
  *
  */
-class LeftCell extends TableCell<IndexEntry, String> {
+class RightCell extends TableCell<IndexEntry, FXOMObject> {
     
     
     /*
@@ -47,24 +49,35 @@ class LeftCell extends TableCell<IndexEntry, String> {
      */
 
     @Override
-    protected void updateItem(String leftValue, boolean empty) {
-        super.updateItem(leftValue, empty);
-        setText(empty ? "" : leftValue); //NOI18N
+    protected void updateItem(FXOMObject rightValue, boolean empty) {
+        super.updateItem(rightValue, empty);
+        
+        final String text;
+        if (empty) {
+            text = ""; //NOI18N
+        } else {
+            if (rightValue == null) {
+                text = "null"; //NOI18N
+            } else {
+                text = rightValue.getGlueElement().getTagName();
+            }
+        }
+        setText(text);
     }
     
     
     
     
     public static class Factory 
-    implements Callback<TableColumn<IndexEntry, String>, TableCell<IndexEntry, String>> {
+    implements Callback<TableColumn<IndexEntry, FXOMObject>, TableCell<IndexEntry, FXOMObject>> {
 
         /*
-         * Callback<TableView<IndexEntry, String>, TableCell<IndexEntry, String>>
+         * Callback<TableView<IndexEntry>, TableCell<IndexEntry, FXOMObject>>
          */
 
         @Override
-        public TableCell<IndexEntry, String> call(TableColumn<IndexEntry, String> tc) {
-            return new LeftCell();
+        public TableCell<IndexEntry, FXOMObject> call(TableColumn<IndexEntry, FXOMObject> tc) {
+            return new RightCell();
         }
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportRow.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportRow.java
@@ -41,12 +41,14 @@ import javafx.beans.property.SimpleBooleanProperty;
  */
 class ImportRow {
 
+    private final boolean originalImportRequired;
     private final BooleanProperty importRequired;
     private final JarReportEntry jre;
     private PrefSize prefSize;
     private final String canonicalClassName;
 
     public ImportRow(boolean importRequired, JarReportEntry jre, PrefSize prefSize) {
+        this.originalImportRequired = importRequired;
         this.importRequired = new SimpleBooleanProperty(importRequired);
         this.jre = jre;
         this.canonicalClassName = jre.getKlass().getCanonicalName();
@@ -68,6 +70,10 @@ class ImportRow {
 
     public void setImportRequired(boolean v) {
         importRequired().set(v);
+    }
+    
+    public boolean isImportRequiredChanged() {
+        return isImportRequired() != originalImportRequired;
     }
 
     public JarReportEntry getJarReportEntry() {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryLocationEnum.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryLocationEnum.java
@@ -1,0 +1,8 @@
+package com.oracle.javafx.scenebuilder.kit.editor.panel.library;
+
+public enum LibraryLocationEnum {
+
+    LOCAL_LIBRARY,
+    MAVEN_ARTIFACT,
+    WORKSPACE_LIBRARY;
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryUtil.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryUtil.java
@@ -44,20 +44,34 @@ import java.util.stream.Collectors;
 public class LibraryUtil {
 
     public static final String FOLDERS_LIBRARY_FILENAME = "library.folders"; //NOI18N
+    public static final String WORKSPACE_LIBRARY_FILENAME = "library-workspace.xml"; //NOI18N
 
     public static boolean isJarPath(Path path) {
+        if (!Files.isRegularFile(path))
+            return false;
+        
         final String pathString = path.toString().toLowerCase(Locale.ROOT);
         return pathString.endsWith(".jar"); //NOI18N
     }
 
     public static boolean isFxmlPath(Path path) {
+        if (!Files.isRegularFile(path))
+            return false;
+        
         final String pathString = path.toString().toLowerCase(Locale.ROOT);
         return pathString.endsWith(".fxml"); //NOI18N
     }
 
     public static boolean isFolderMarkerPath(Path path) {
+        if (!Files.isRegularFile(path))
+            return false;
+        
         final String pathString = path.toString().toLowerCase(Locale.ROOT);
         return pathString.endsWith(".folders"); //NOI18N
+    }
+    
+    public static boolean isWorkspacePath(Path path) {
+        return path.toFile().getName().equals(WORKSPACE_LIBRARY_FILENAME);
     }
 
     public static List<Path> getFolderPaths(Path libraryFile) throws FileNotFoundException, IOException {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogListCell.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogListCell.java
@@ -32,12 +32,13 @@
 
 package com.oracle.javafx.scenebuilder.kit.editor.panel.library.manager;
 
-import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.oracle.javafx.scenebuilder.kit.editor.images.ImageUtils;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.ErrorDialog;
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -53,9 +54,12 @@ import javafx.scene.layout.Priority;
 public class LibraryDialogListCell extends ListCell<DialogListItem> {
 
     private DialogListItem dialogListItem;
+    private boolean itemOnWorkspace;
 
-    public LibraryDialogListCell() {
+    public LibraryDialogListCell(boolean itemOnWorkspace) {
         super();
+        
+        this.itemOnWorkspace = itemOnWorkspace;
     }
 
     @Override
@@ -94,10 +98,29 @@ public class LibraryDialogListCell extends ListCell<DialogListItem> {
         buttonContent.setSpacing(5);
         Button editButton = new Button("", new ImageView(ImageUtils.getEditIconImage()));
         editButton.getStyleClass().add("image-view-button");
-        editButton.setOnMouseClicked(event -> dialogListItem.getLibraryDialogController().processJarFXMLFolderEdit(dialogListItem));
+        if (itemOnWorkspace)
+            editButton.setOnMouseClicked(event -> dialogListItem.getLibraryDialogController().processWorkspaceJarFXMLFolderEdit(dialogListItem));
+        else
+            editButton.setOnMouseClicked(event -> dialogListItem.getLibraryDialogController().processJarFXMLFolderEdit(dialogListItem));
         editButton.setTooltip(new Tooltip(I18N.getString("library.dialog.button.edit.tooltip")));
         Button deleteButton = new Button("", new ImageView(ImageUtils.getDeleteIconImage()));
-        deleteButton.setOnMouseClicked(event -> dialogListItem.getLibraryDialogController().processJarFXMLFolderDelete(dialogListItem));
+        if (itemOnWorkspace)
+            deleteButton.setOnMouseClicked(event -> {
+                try {
+                    dialogListItem.getLibraryDialogController().processWorkspaceJarFXMLFolderDelete(dialogListItem);
+                } catch (Exception ex) {
+                    Logger.getLogger(LibraryDialogListCell.class.getName()).log(Level.SEVERE, ex.getMessage(), ex);
+                    
+                    ErrorDialog errorDialog = new ErrorDialog(null);
+                    errorDialog.setTitle(I18N.getString("library.dialog.button.deletefail.title"));
+                    errorDialog.setMessage(ex.getLocalizedMessage());
+                    errorDialog.setDetails(ex.getLocalizedMessage());
+                    errorDialog.setDebugInfoWithThrowable(ex);
+                    errorDialog.showAndWait();
+                }
+            });
+        else
+            deleteButton.setOnMouseClicked(event -> dialogListItem.getLibraryDialogController().processJarFXMLFolderDelete(dialogListItem));
         deleteButton.getStyleClass().add("image-view-button");
         deleteButton.setTooltip(new Tooltip(I18N.getString("library.dialog.button.delete.tooltip")));
         buttonContent.getChildren().addAll(editButton, deleteButton);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/MavenDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/MavenDialogController.java
@@ -34,6 +34,7 @@ package com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.ImportWindowController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryLocationEnum;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryPanelController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlWindowController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog.ButtonID;
@@ -189,7 +190,7 @@ public class MavenDialogController extends AbstractFxmlWindowController {
                             = new ImportWindowController(
                             new LibraryPanelController(editorController, preferencesControllerBase.getMavenPreferences()),
                             files, preferencesControllerBase.getMavenPreferences(),
-                            (Stage)installButton.getScene().getWindow(), false,
+                            (Stage)installButton.getScene().getWindow(), LibraryLocationEnum.MAVEN_ARTIFACT,
                                 preferencesControllerBase.getMavenPreferences().getArtifactsFilter());
                     iwc.setToolStylesheet(editorController.getToolStylesheet());
                     ButtonID userChoice = iwc.showAndWait();

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/search/SearchMavenDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/search/SearchMavenDialogController.java
@@ -34,6 +34,7 @@ package com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.search;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.ImportWindowController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryLocationEnum;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryPanelController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.MavenArtifact;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.MavenRepositorySystem;
@@ -166,7 +167,7 @@ public class SearchMavenDialogController extends AbstractFxmlWindowController {
                                     new LibraryPanelController(editorController,
                                             preferencesControllerBase.getMavenPreferences()),
                                     files, preferencesControllerBase.getMavenPreferences(),
-                                    (Stage) installButton.getScene().getWindow(), false,
+                                    (Stage) installButton.getScene().getWindow(), LibraryLocationEnum.MAVEN_ARTIFACT,
                                     preferencesControllerBase.getMavenPreferences().getArtifactsFilter());
                         iwc.setToolStylesheet(editorController.getToolStylesheet());
                         ButtonID userChoice = iwc.showAndWait();

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMArchive.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMArchive.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -52,7 +53,7 @@ public class FXOMArchive implements Serializable {
         
         for (FXOMObject o : fxomObjects) {
             final URL location = o.getFxomDocument().getLocation();
-            final String fxmlText = FXOMNodes.newDocument(o).getFxmlText();
+            final String fxmlText = FXOMNodes.newDocument(o).getFxmlText(false);
             entries.add(new Entry(fxmlText, location));
         }
     }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Gluon and/or its affiliates.
+ * Copyright (c) 2017, 2019 Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -54,8 +54,6 @@ import com.oracle.javafx.scenebuilder.kit.fxom.glue.GlueDocument;
 import com.oracle.javafx.scenebuilder.kit.fxom.sampledata.SampleDataGenerator;
 import com.oracle.javafx.scenebuilder.kit.util.Deprecation;
 import com.oracle.javafx.scenebuilder.kit.util.URLUtils;
-import java.util.ArrayList;
-import java.util.List;
 import javafx.scene.Parent;
 
 /**
@@ -249,7 +247,12 @@ public class FXOMDocument {
         return displayNode != null ? displayNode : sceneGraphRoot;
     }
 
-    public String getFxmlText() {
+    /**
+     * Returns the FXML string representation of the FXOMDocument.
+     * @param wildcardImports If the FXML should have wildcards in its imports.
+     * @return The FXML string representation. This can be empty if current root is null.
+     */
+    public String getFxmlText(boolean wildcardImports) {
         final String result;
         if (fxomRoot == null) {
             assert glue.getRootElement() == null;
@@ -259,7 +262,7 @@ public class FXOMDocument {
             assert glue.getRootElement() != null;
             // Note that sceneGraphRoot might be null if fxomRoot is unresolved
             glue.updateIndent();
-            final FXOMSaver saver = new FXOMSaver();
+            final FXOMSaver saver = new FXOMSaver(wildcardImports);
             result = saver.save(this);
         }
         return result;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -46,7 +47,6 @@ import javafx.stage.Window;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -59,7 +59,7 @@ class FXOMRefresher {
     public void refresh(FXOMDocument document) {
         String fxmlText = null;
         try {
-            fxmlText = document.getFxmlText();
+            fxmlText = document.getFxmlText(false);
             final FXOMDocument newDocument
                     = new FXOMDocument(fxmlText,
                     document.getLocation(),

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
@@ -57,8 +57,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
 import com.oracle.javafx.scenebuilder.kit.editor.images.ImageUtils;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryUtil;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
@@ -302,7 +300,7 @@ class LibraryFolderWatcher implements Runnable {
                 try {
                     watchService.close();
                 } catch (IOException e) {
-                    Logger.getLogger(LibraryFolderWatcher.class.getName()).severe(ExceptionUtils.getStackTrace(e));
+                    Logger.getLogger(LibraryFolderWatcher.class.getName()).log(Level.SEVERE, e.getMessage(), e);
                 }
             }
         }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
@@ -53,18 +53,24 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import com.oracle.javafx.scenebuilder.kit.editor.images.ImageUtils;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryUtil;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
 import com.oracle.javafx.scenebuilder.kit.library.BuiltinLibrary;
 import com.oracle.javafx.scenebuilder.kit.library.LibraryItem;
+import com.oracle.javafx.scenebuilder.kit.library.user.ws.UserLibraryWorkspace;
+import com.oracle.javafx.scenebuilder.kit.library.user.ws.UserWorkspaceLibraryItem;
 import com.oracle.javafx.scenebuilder.kit.library.util.FolderExplorer;
 import com.oracle.javafx.scenebuilder.kit.library.util.JarExplorer;
 import com.oracle.javafx.scenebuilder.kit.library.util.JarReport;
 import com.oracle.javafx.scenebuilder.kit.library.util.JarReportEntry;
+import com.thoughtworks.xstream.XStreamException;
 
 /**
  *
@@ -129,6 +135,21 @@ class LibraryFolderWatcher implements Runnable {
                             for (Path f : folderPaths) {
                                 currentJarsOrFolders.add(f);
                             }
+                        } else if (LibraryUtil.isWorkspacePath(entry)) {
+
+                            UserLibraryWorkspace workspace = library.getUserWorkspace();
+
+                            for (UserWorkspaceLibraryItem item : workspace.getItems()) {
+
+                                String path = item.getPath();
+                                Path p = Paths.get(path);
+
+                                if (LibraryUtil.isJarPath(p) || Files.isDirectory(p)) {
+                                    currentJarsOrFolders.add(p);
+                                } else if (LibraryUtil.isFxmlPath(p)) {
+                                    currentFxmls.add(p);
+                                }
+                            }
                         }
                     }
                     retry = false;
@@ -154,98 +175,136 @@ class LibraryFolderWatcher implements Runnable {
     }
     
     private void runWatching() throws InterruptedException {
-        while (true) {
-            final Path folder = Paths.get(library.getPath());
+        WatchService watchService = null;
+        try {
+            while (true) {
+                final Path folder = Paths.get(library.getPath());
 
-            WatchService watchService = null;
-            while (watchService == null) {
-                try {
-                    watchService = folder.getFileSystem().newWatchService();
-                } catch(IOException x) {
-                    System.out.println("FileSystem.newWatchService() failed"); //NOI18N
-                    System.out.println("Sleeping..."); //NOI18N
-                    Thread.sleep(1000 /* ms */);
+                while (watchService == null) {
+                    try {
+                        watchService = folder.getFileSystem().newWatchService();
+                    } catch(IOException x) {
+                        System.out.println("FileSystem.newWatchService() failed"); //NOI18N
+                        System.out.println("Sleeping..."); //NOI18N
+                        Thread.sleep(1000 /* ms */);
+                    }
                 }
-            }
 
-            WatchKey watchKey = null;
-            while ((watchKey == null) || (watchKey.isValid() == false)) {
-                try {
-                    watchKey = folder.register(watchService, 
-                    StandardWatchEventKinds.ENTRY_CREATE, 
-                    StandardWatchEventKinds.ENTRY_DELETE, 
-                    StandardWatchEventKinds.ENTRY_MODIFY);
+                WatchKey watchKey = null;
+                while ((watchKey == null) || (watchKey.isValid() == false)) {
+                    try {
+                        watchKey = folder.register(watchService, 
+                                StandardWatchEventKinds.ENTRY_CREATE, 
+                                StandardWatchEventKinds.ENTRY_DELETE, 
+                                StandardWatchEventKinds.ENTRY_MODIFY);
 
-                    WatchKey wk;
-                    do {
-                        wk = watchService.take();
-                        assert wk == watchKey;
-                        
-                        boolean isDirty = false;
-                        for (WatchEvent<?> e: wk.pollEvents()) {
-                            final WatchEvent.Kind<?> kind = e.kind();
-                            final Object context = e.context();
+                        WatchKey wk;
+                        do {
+                            wk = watchService.take();
+                            assert wk == watchKey;
 
-                            if (kind == StandardWatchEventKinds.ENTRY_CREATE
-                                    || kind == StandardWatchEventKinds.ENTRY_DELETE
-                                    || kind == StandardWatchEventKinds.ENTRY_MODIFY) {
-                                assert context instanceof Path;
-                                if (LibraryUtil.isJarPath((Path) context)) {
-                                    if (!hasJarBeenAdded((Path) context)) {
+                            boolean isDirty = false;
+                            for (WatchEvent<?> e: wk.pollEvents()) {
+                                final WatchEvent.Kind<?> kind = e.kind();
+                                final Object context = e.context();
+
+                                if (kind == StandardWatchEventKinds.ENTRY_CREATE
+                                        || kind == StandardWatchEventKinds.ENTRY_DELETE
+                                        || kind == StandardWatchEventKinds.ENTRY_MODIFY) {
+                                    assert context instanceof Path;
+                                    if (LibraryUtil.isJarPath((Path) context)) {
+                                        if (!hasJarBeenAdded((Path) context)) {
+                                            isDirty = true;
+                                        }
+                                    } else if (LibraryUtil.isFxmlPath((Path)context)){
+                                        isDirty = true;
+                                    } else if (LibraryUtil.isFolderMarkerPath((Path)context)) {
+                                        isDirty = true;
+                                    } else if (LibraryUtil.isWorkspacePath((Path)context)) {
                                         isDirty = true;
                                     }
-                                } else if (LibraryUtil.isFxmlPath((Path)context)){
-                                    isDirty = true;
-                                } else if (LibraryUtil.isFolderMarkerPath((Path)context)) {
-                               		isDirty = true;
+                                } else {
+                                    assert kind == StandardWatchEventKinds.OVERFLOW;
                                 }
-                            } else {
-                                assert kind == StandardWatchEventKinds.OVERFLOW;
                             }
-                        }
-                                                
-                        // We reconstruct a full set from scratch as soon as the
-                        // dirty flag is set.
-                        if (isDirty) {
-                            // First put the builtin items in the library
-                        	library.setExploring(true);
-                        	try {
-                        	    library.setItems(BuiltinLibrary.getLibrary().getItems());
 
-                        	    // Now attempts to add the maven jars
-                        	    List<Path> currentMavenJars = library.getAdditionalJarPaths().get();
+                            // We reconstruct a full set from scratch as soon as the
+                            // dirty flag is set.
+                            if (isDirty) {
+                                // First put the builtin items in the library
+                                library.setExploring(true);
+                                try {
+                                    library.setItems(BuiltinLibrary.getLibrary().getItems());
 
-                        	    final Set<Path> fxmls = new HashSet<>();
-                        	    fxmls.addAll(getAllFiles(FILE_TYPE.FXML));
-                        	    updateLibrary(fxmls);
+                                    // Now attempts to add the maven jars
+                                    List<Path> currentMavenJars = library.getAdditionalJarPaths().get();
 
-                        	    final Set<Path> jarsAndFolders = new HashSet<>(currentMavenJars);
-                        	    jarsAndFolders.addAll(getAllFiles(FILE_TYPE.JAR));
+                                    final Set<Path> fxmls = new HashSet<>();
+                                    fxmls.addAll(getAllFiles(FILE_TYPE.FXML));
 
-                        	    Set<Path> foldersMarkers = getAllFiles(FILE_TYPE.FOLDER_MARKER);
-                        	    for (Path path : foldersMarkers) {
-                        	        // open folders marker file: every line should be a single folder entry
-                        	        // we scan the file and add the path to currentJarsOrFolders
-                        	        List<Path> folderPaths = LibraryUtil.getFolderPaths(path);
-                        	        for (Path f : folderPaths) {
-                        	            jarsAndFolders.add(f);
-                        	        }
-                        	    }
+                                    final Set<Path> jarsAndFolders = new HashSet<>(currentMavenJars);
+                                    jarsAndFolders.addAll(getAllFiles(FILE_TYPE.JAR));
 
-                        	    exploreAndUpdateLibrary(jarsAndFolders);
+                                    Set<Path> foldersMarkers = getAllFiles(FILE_TYPE.FOLDER_MARKER);
+                                    for (Path path : foldersMarkers) {
+                                        // open folders marker file: every line should be a single folder entry
+                                        // we scan the file and add the path to currentJarsOrFolders
+                                        List<Path> folderPaths = LibraryUtil.getFolderPaths(path);
+                                        for (Path f : folderPaths) {
+                                            jarsAndFolders.add(f);
+                                        }
+                                    }
 
-                        	    library.updateExplorationCount(library.getExplorationCount()+1);
-                        	}
-                        	finally {
-                        		library.setExploring(false);
-                        	}
-                        }
-                    } while (wk.reset());
-                } catch(IOException x) {
-                    Thread.sleep(1000 /* ms */);
+                                    try {
+                                        Path workspacePath = Paths.get(library.getPath(), LibraryUtil.WORKSPACE_LIBRARY_FILENAME);
+                                        UserLibraryWorkspace workspace = UserLibraryWorkspace.fromXml(workspacePath.toUri().toURL());
+                                        library.setUserWorkspace(workspace);
+
+                                        for (UserWorkspaceLibraryItem item : workspace.getItems()) {
+
+                                            String path = item.getPath();
+                                            Path p = Paths.get(path);
+
+                                            if (LibraryUtil.isJarPath(p) || Files.isDirectory(p)) {
+                                                jarsAndFolders.add(p);
+                                            } else if (LibraryUtil.isFxmlPath(p)) {
+                                                fxmls.add(p);
+                                            }
+                                        }
+
+                                    } catch (XStreamException ex) {
+                                        // not a valid xml file, nor a valid workspace file
+                                        Logger.getLogger(LibraryFolderWatcher.class.getName()).log(Level.SEVERE, ex.getMessage(), ex);
+
+                                        library.setUserWorkspace(new UserLibraryWorkspace());
+                                    }
+
+                                    updateLibrary(fxmls);
+                                    exploreAndUpdateLibrary(jarsAndFolders);
+
+                                    library.updateExplorationCount(library.getExplorationCount()+1);
+                                }
+                                finally {
+                                    library.setExploring(false);
+                                }
+                            }
+                        } while (wk.reset());
+                    } catch(IOException x) {
+                        Thread.sleep(1000 /* ms */);
+                    }
+                }
+
+            }
+        }
+        finally {
+            if (watchService != null) {
+                // we need to close the filesystem watcher here, otherwise it remains active and locking jars on library folder
+                try {
+                    watchService.close();
+                } catch (IOException e) {
+                    Logger.getLogger(LibraryFolderWatcher.class.getName()).severe(ExceptionUtils.getStackTrace(e));
                 }
             }
-
         }
     }
 
@@ -403,6 +462,7 @@ class LibraryFolderWatcher implements Runnable {
         final List<LibraryItem> result = new ArrayList<>();
         final URL iconURL = ImageUtils.getNodeIconURL(null);
         final List<String> excludedItems = library.getFilter();
+        final List<String> excludedWorkspaceItems = library.getWorkspaceFilter();
         final List<String> artifactsFilter = library.getAdditionalFilter().get();
                 
         for (JarReportEntry e : jarOrFolderReport.getEntries()) {
@@ -410,7 +470,8 @@ class LibraryFolderWatcher implements Runnable {
                 // We filter out items listed in the excluded list, based on canonical name of the class.
                 final String canonicalName = e.getKlass().getCanonicalName();
                 if (!excludedItems.contains(canonicalName) && 
-                    !artifactsFilter.contains(canonicalName)) {
+                    !artifactsFilter.contains(canonicalName) &&
+                    !excludedWorkspaceItems.contains(canonicalName)) {
                     final String name = e.getKlass().getSimpleName();
                     final String fxmlText = JarExplorer.makeFxmlText(e.getKlass());
                     result.add(new LibraryItem(name, UserLibrary.TAG_USER_DEFINED, fxmlText, iconURL, library));

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/UserLibrary.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/UserLibrary.java
@@ -262,7 +262,6 @@ public class UserLibrary extends Library {
                     for (String classname : allClassnames) {
                         writer.write(classname + "\n"); //NOI18N
                     }
-                    writer.flush();
                 }
 
                 // Delete the former filter file

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/ws/UserLibraryFilter.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/ws/UserLibraryFilter.java
@@ -1,0 +1,50 @@
+package com.oracle.javafx.scenebuilder.kit.library.user.ws;
+
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+public class UserLibraryFilter {
+
+    @XStreamAsAttribute private String className;
+
+    public UserLibraryFilter(String className) {
+        this.className = className;
+    }
+    
+    public String getClassName() {
+        return className;
+    }
+    public void setClassName(String className) {
+        this.className = className;
+    }
+    
+    @Override
+    public String toString() {
+        return className;
+    }
+    
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((className == null) ? 0 : className.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        UserLibraryFilter other = (UserLibraryFilter) obj;
+        if (className == null) {
+            if (other.className != null)
+                return false;
+        } else if (!className.equals(other.className))
+            return false;
+        return true;
+    }
+    
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/ws/UserLibraryWorkspace.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/ws/UserLibraryWorkspace.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2019, Gluon and/or its affiliates.
+ * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.library.user.ws;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+
+import org.xml.sax.InputSource;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.io.xml.StaxDriver;
+
+@XStreamAlias("LibraryWorkspace")
+public class UserLibraryWorkspace {
+
+    @XStreamAlias("Items") private Set<UserWorkspaceLibraryItem> items = new LinkedHashSet<>();
+    @XStreamAlias("Filters") private Set<UserLibraryFilter> filters = new LinkedHashSet<>();
+    
+    
+    public Set<UserWorkspaceLibraryItem> getItems() {
+        return items;
+    }
+    public Set<UserLibraryFilter> getFilters() {
+        return filters;
+    }
+    
+    public void removeItem(Path path) {
+        for (Iterator<UserWorkspaceLibraryItem> it = items.iterator(); it.hasNext();) {
+            UserWorkspaceLibraryItem item = it.next();
+            String itemPath = item.getPath();
+            
+            if (path.toString().equals(itemPath))
+                it.remove();
+        }
+    }
+    
+    protected static XStream createXStream() {
+        XStream xs = new XStream(new StaxDriver());
+        XStream.setupDefaultSecurity(xs);
+        xs.autodetectAnnotations(true);
+        xs.allowTypesByWildcard(new String[] { UserLibraryWorkspace.class.getPackage().getName() + ".**" }); // see https://stackoverflow.com/questions/44698296/security-framework-of-xstream-not-initialized-xstream-is-probably-vulnerable
+        xs.alias("LibraryWorkspace", UserLibraryWorkspace.class);
+        xs.alias("Item", UserWorkspaceLibraryItem.class);
+        xs.alias("Filter", UserLibraryFilter.class);
+        return xs;
+    }
+    
+    public static UserLibraryWorkspace fromXml(String xml) {
+        return (UserLibraryWorkspace) createXStream().fromXML(xml);
+    }
+    public static UserLibraryWorkspace fromXml(Reader reader) {
+        return (UserLibraryWorkspace) createXStream().fromXML(reader);
+    }
+    public static UserLibraryWorkspace fromXml(InputStream is) {
+        return (UserLibraryWorkspace) createXStream().fromXML(is);
+    }
+    public static UserLibraryWorkspace fromXml(URL url) {
+        return (UserLibraryWorkspace) createXStream().fromXML(url);
+    }
+    
+    public String toXml() {
+        return formatXml(createXStream().toXML(this));
+    }
+    
+    protected static String formatXml(String xml) {
+        try {
+            Transformer serializer = SAXTransformerFactory.newInstance().newTransformer();
+
+            serializer.setOutputProperty(OutputKeys.INDENT, "yes"); //$NON-NLS-1$
+            serializer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4"); //$NON-NLS-1$ //$NON-NLS-2$
+
+            Source xmlSource = new SAXSource(new InputSource(new StringReader(xml)));
+            StreamResult res =  new StreamResult(new ByteArrayOutputStream());
+
+            serializer.transform(xmlSource, res);
+
+            return new String(((ByteArrayOutputStream) res.getOutputStream()).toByteArray());
+        }
+        catch (RuntimeException ex) {
+            throw ex;
+        }
+        catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public void mergeWith(UserLibraryWorkspace workspace) {
+        items.addAll(workspace.items);
+        filters.addAll(workspace.filters);
+    }
+    
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/ws/UserWorkspaceLibraryItem.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/ws/UserWorkspaceLibraryItem.java
@@ -1,0 +1,52 @@
+package com.oracle.javafx.scenebuilder.kit.library.user.ws;
+
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * This class contains a path to a jar or an fxml or to a folder.
+ */
+public class UserWorkspaceLibraryItem {
+
+    @XStreamAsAttribute private String path;
+
+    public UserWorkspaceLibraryItem(String path) {
+        this.path = path;
+    }
+    
+    public String getPath() {
+        return path;
+    }
+    public void setPath(String path) {
+        this.path = path;
+    }
+    
+    @Override
+    public String toString() {
+        return path;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((path == null) ? 0 : path.hashCode());
+        return result;
+    }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        UserWorkspaceLibraryItem other = (UserWorkspaceLibraryItem) obj;
+        if (path == null) {
+            if (other.path != null)
+                return false;
+        } else if (!path.equals(other.path))
+            return false;
+        return true;
+    }
+    
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preferences/PreferencesControllerBase.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preferences/PreferencesControllerBase.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2017, 2019, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.oracle.javafx.scenebuilder.kit.preferences;
 
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.MavenArtifact;
@@ -30,6 +61,7 @@ public abstract class PreferencesControllerBase {
     public static final String LIBRARY_DISPLAY_OPTION = "LIBRARY_DISPLAY_OPTION"; //NOI18N
     public static final String HIERARCHY_DISPLAY_OPTION = "HIERARCHY_DISPLAY_OPTION"; //NOI18N
     public static final String ACCORDION_ANIMATION = "ACCORDION_ANIMATION"; //NOI18N
+    public static final String WILDCARD_IMPORT = "WILDCARD_IMPORT"; //NOI18N
 
     // DOCUMENT SPECIFIC PREFERENCES
     public static final String PATH = "path"; //NOI18N

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2019, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -70,7 +70,6 @@ import javafx.scene.transform.Scale;
 import javafx.scene.transform.Translate;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
-import javafx.stage.Window;
 import javafx.stage.WindowEvent;
 
 /**
@@ -212,7 +211,7 @@ public final class PreviewWindowController extends AbstractWindowController {
         // We clone the FXOMDocument
         FXOMDocument clone;
         try {
-            clone = new FXOMDocument(fxomDocument.getFxmlText(),
+            clone = new FXOMDocument(fxomDocument.getFxmlText(false),
                     fxomDocument.getLocation(),
                     fxomDocument.getClassLoader(),
                     fxomDocument.getResources());
@@ -278,7 +277,7 @@ public final class PreviewWindowController extends AbstractWindowController {
                     FXOMDocument clone;
 
                     try {
-                        clone = new FXOMDocument(fxomDocument.getFxmlText(),
+                        clone = new FXOMDocument(fxomDocument.getFxmlText(false),
                                 fxomDocument.getLocation(),
                                 fxomDocument.getClassLoader(),
                                 fxomDocument.getResources());

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/info/InfoPanel.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/info/InfoPanel.fxml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2019, Gluon and/or its affiliates.
+  Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+  All rights reserved. Use is subject to license terms.
+
+  This file is available and licensed under the following license:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the distribution.
+  - Neither the name of Oracle Corporation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<?import java.lang.String?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<ScrollPane fitToHeight="true" fitToWidth="true" prefHeight="300.0" prefWidth="270.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <content>
+        <VBox id="StackPane" spacing="7.0">
+            <children>
+        <VBox fx:id="controllerClassVBox" alignment="CENTER" spacing="0.0">
+            <children>
+                <HBox fx:id="controllerAndCogHBox" maxWidth="1.7976931348623157E308" prefHeight="-1.0" prefWidth="-1.0" />
+            </children>
+            <VBox.margin>
+                <Insets top="8.0" />
+            </VBox.margin>
+        </VBox>
+        <CheckBox fx:id="fxrootCheckBox" mnemonicParsing="false" text="%info.label.use.fx.root" />
+        <VBox id="VBox" alignment="CENTER" spacing="5.0">
+            <children>
+                <Label maxWidth="1.7976931348623157E308" text="%info.label.assigned" />
+                <TableView minHeight="100.0" VBox.vgrow="ALWAYS">
+                    <columnResizePolicy>
+                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                    </columnResizePolicy>
+                    <columns>
+                        <TableColumn fx:id="leftTableColumn" maxWidth="1.7976931348623157E308" minWidth="30.0" prefWidth="-1.0" resizable="true" sortable="true" text="fx:id" />
+                        <TableColumn fx:id="rightTableColumn" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" sortable="true" text="%info.label.component" />
+                    </columns>
+                    <sortOrder>
+                        <fx:reference source="leftTableColumn" />
+                    </sortOrder>
+                </TableView>
+                <Label fx:id="bottomLabel" alignment="CENTER" maxHeight="-Infinity" maxWidth="1.7976931348623157E308" minHeight="-Infinity" styleClass="small-label" text="Label" textAlignment="LEFT" VBox.vgrow="NEVER">
+                    <VBox.margin>
+                        <Insets bottom="4.0" />
+                    </VBox.margin>
+                </Label>
+            </children>
+          <VBox.margin>
+            <Insets right="10.0" top="10.0" />
+          </VBox.margin>
+        </VBox>
+            </children>
+            <padding>
+                <Insets left="10.0" />
+            </padding>
+        </VBox>
+    </content>
+    <styleClass>
+    <String fx:value="theme-presets" />
+    <String fx:value="property-sheet" />
+    </styleClass>
+</ScrollPane>

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryDialog.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryDialog.fxml
@@ -35,21 +35,27 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ContextMenu?>
 <?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
+<?import javafx.scene.control.MenuButton?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.SeparatorMenuItem?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.RowConstraints?>
 
-<AnchorPane fx:id="LibraryDialog" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="300.0" minWidth="300.0" prefHeight="468.0" prefWidth="500.0" styleClass="theme-presets" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane fx:id="LibraryDialog" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="300.0" minWidth="300.0" prefHeight="468.0" prefWidth="830.0" styleClass="theme-presets" xmlns="http://javafx.com/javafx/11.0.2" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <GridPane hgap="5.0" prefHeight="380.0" prefWidth="520.0" vgap="5.0" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="10.0">
          <columnConstraints>
             <ColumnConstraints hgrow="NEVER" maxWidth="10.0" minWidth="10.0" prefWidth="10.0" />
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="200.0" prefWidth="429.0" />
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity" prefWidth="10.0" />
             <ColumnConstraints hgrow="SOMETIMES" minWidth="200.0" prefWidth="429.0" />
          </columnConstraints>
          <rowConstraints>
@@ -64,27 +70,65 @@
             <RowConstraints minHeight="40.0" prefHeight="40.0" vgrow="SOMETIMES" />
          </rowConstraints>
          <children>
-            <Label prefHeight="17.0" prefWidth="200.0" text="%library.dialog.label.installed" GridPane.columnSpan="2" GridPane.halignment="LEFT" />
+            <BorderPane GridPane.columnSpan="2" GridPane.halignment="LEFT">
+               <left>
+                  <Label prefHeight="17.0" text="%library.dialog.label.installed" BorderPane.alignment="CENTER" />
+               </left>
+            </BorderPane>
             <ListView fx:id="libraryListView" prefHeight="134.0" prefWidth="510.0" GridPane.columnSpan="2" GridPane.rowIndex="1">
                 <placeholder>
                     <Label text="%no.items.found" />
                  </placeholder>
             </ListView>
             <Label prefHeight="17.0" prefWidth="577.0" text="%library.dialog.label.install" GridPane.columnSpan="2" GridPane.rowIndex="2" />
-            <HBox alignment="CENTER_RIGHT" spacing="10.0" GridPane.columnSpan="2" GridPane.rowIndex="8">
-               <children>
-                  <Pane prefHeight="15.0" prefWidth="324.0" HBox.hgrow="ALWAYS" />
-                  <Button fx:id="closeButton" layoutX="317.0" layoutY="17.0" minWidth="70.0" mnemonicParsing="false" onAction="#close" text="%library.dialog.button.close" />
-               </children>
-            </HBox>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0" GridPane.columnSpan="2" GridPane.rowIndex="8" />
             <Hyperlink onAction="#addRelease" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.release" GridPane.columnIndex="1" GridPane.rowIndex="3">
                <GridPane.margin>
                   <Insets />
                </GridPane.margin></Hyperlink>
             <Hyperlink layoutX="15.0" layoutY="298.0" onAction="#addManually" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.manually" GridPane.columnIndex="1" GridPane.rowIndex="4" />
-            <Hyperlink layoutX="15.0" layoutY="298.0" onAction="#addJar" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.jar" GridPane.columnIndex="1" GridPane.rowIndex="5" />
-            <Hyperlink fx:id="classesLink" onAction="#addFolder" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.folder" GridPane.columnIndex="1" GridPane.rowIndex="6" />
-            <Hyperlink layoutX="30.0" layoutY="316.0" onAction="#manage" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.repositories" GridPane.columnIndex="1" GridPane.rowIndex="7" />
+            <Hyperlink layoutX="15.0" layoutY="298.0" onAction="#addJar" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.jar" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+            <Hyperlink fx:id="classesLink" onAction="#addFolder" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.folder" GridPane.columnIndex="1" GridPane.rowIndex="7" />
+            <ListView fx:id="workspaceLibraryListView" prefHeight="134.0" prefWidth="510.0" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.rowIndex="1">
+               <placeholder>
+                  <Label text="%no.items.found" />
+               </placeholder>
+            </ListView>
+            <BorderPane GridPane.columnIndex="2" GridPane.columnSpan="2">
+               <left>
+                  <Label prefHeight="17.0" text="%library.dialog.label.installedworkspace" BorderPane.alignment="CENTER" />
+               </left>
+               <right>
+                  <HBox alignment="CENTER_RIGHT" BorderPane.alignment="CENTER">
+                     <children>
+                        <MenuButton mnemonicParsing="false" text="%library.dialog.button.workspacemenu">
+                          <items>
+                            <MenuItem mnemonicParsing="false" onAction="#importReplaceWorkspace" text="%library.dialog.hyperlink.importworkspace" />
+                              <MenuItem mnemonicParsing="false" onAction="#importMergeWorkspace" text="%library.dialog.hyperlink.importmergeworkspace" />
+                              <SeparatorMenuItem mnemonicParsing="false" />
+                            <MenuItem mnemonicParsing="false" onAction="#exportWorkspace" text="%library.dialog.hyperlink.exportworkspace" />
+                          </items>
+                           <contextMenu>
+                              <ContextMenu>
+                                <items>
+                                  <MenuItem mnemonicParsing="false" text="Unspecified Action" />
+                                </items>
+                              </ContextMenu>
+                           </contextMenu>
+                        </MenuButton>
+                     </children>
+                  </HBox>
+               </right>
+            </BorderPane>
+            <Hyperlink onAction="#linkJar" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.jarworkspace" GridPane.columnIndex="3" GridPane.rowIndex="6" />
+            <Hyperlink fx:id="workspaceFolderLink" onAction="#linkFolder" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.folderworkspace" GridPane.columnIndex="3" GridPane.rowIndex="7" />
+            <BorderPane GridPane.columnIndex="3" GridPane.rowIndex="8">
+               <right>
+                  <Button fx:id="closeButton" minWidth="70.0" mnemonicParsing="false" onAction="#close" text="%library.dialog.button.close" BorderPane.alignment="CENTER" />
+               </right>
+            </BorderPane>
+            <Hyperlink onAction="#manage" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.repositories" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+            <Label fx:id="actionsForWorkspaceLabel" prefHeight="17.0" prefWidth="577.0" text="%library.dialog.label.installworkspace" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.rowIndex="2" />
          </children>
          <padding>
             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, 2017, Gluon and/or its affiliates.
+# Copyright (c) 2016, 2019, Gluon and/or its affiliates.
 # Copyright (c) 2012, 2014, Oracle and/or its affiliates.
 # All rights reserved. Use is subject to license terms.
 #
@@ -100,6 +100,19 @@ hierarchy.unresolved.class = Unresolved class
 hierarchy.unresolved.location = Unresolved location
 hierarchy.unresolved.resource = Unresolved resource
 hierarchy.unsupported.expression = Unsupported by Scene Builder
+
+# -----------------------------------------------------------------------------
+# Info panel
+# -----------------------------------------------------------------------------
+info.label.assigned = Assigned fx:id
+info.label.component = Component
+info.label.use.fx.root = Use fx:root construct
+# Used after number 1
+info.label.item = item
+# Used after any number greater than 1
+info.label.items = items
+# The parameter is the name of a Java class
+info.tooltip.controller = Your Controller class must extend {0}
 
 # -----------------------------------------------------------------------------
 # Content Panel

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
@@ -235,17 +235,31 @@ library.dialog.title =Library Manager
 library.dialog.hyperlink.release = Search repositories
 library.dialog.hyperlink.manually = Manually add Library from repository
 library.dialog.hyperlink.folder = Add root folder with *.class files
+library.dialog.hyperlink.folderworkspace = Link root folder with *.class files
 library.dialog.hyperlink.tooltip = Use this option to specify the root folder under which to scan for controls.\nE.g. add the bin/ folder produced by your IDE during development of custom components.
+library.dialog.hyperlink.tooltipworkspace = Use this option to specify the root folder under which to scan for controls.\nE.g. add the bin/ folder produced by your IDE during development of custom components.\nThis command applies to current workspace only.
 library.dialog.hyperlink.jar = Add Library/FXML from file system
+library.dialog.hyperlink.jarworkspace = Link Library/FXML from file system
 library.dialog.hyperlink.repositories = Manage repositories
+library.dialog.hyperlink.importworkspace = Import and replace
+library.dialog.hyperlink.importmergeworkspace = Import and merge
+library.dialog.hyperlink.exportworkspace = Export
 
 library.dialog.label.installed = Installed Libraries/FXML Files:
+library.dialog.label.installedworkspace = Workspace Libraries/FXML Files:
 library.dialog.label.install = Actions:
+library.dialog.label.installworkspace = Actions for current workspace:
+library.dialog.label.installworkspace.tooltip = Libraries and FXML installed in current workspace are linked to thier original filesystem location and can be imported/exported via the proper import/export links.
 
 library.dialog.button.edit.tooltip = Press to edit the library/FXML file
 library.dialog.button.delete.tooltip = Press to delete the library/FXML file
+library.dialog.button.deletefail.title = Error deleting resource
+library.dialog.button.workspacemenu = Options
 
 library.dialog.button.close = Close
+
+library.dialog.exportfail = Error exporting workspace
+library.dialog.importfail = Error importing workspace
 
 # -----------------------------------------------------------------------------
 # Maven Dialog
@@ -498,6 +512,7 @@ label.no.document = No document
 # Other (from app i18n)
 # -----------------------------------------------------------------------------
 file.filter.label.fxml = FXML Document
+file.filter.label.xml = XML Document
 
 # -----------------------------------------------------------------------------
 # Alert (from app i18n)

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMSaverUpdateImportInstructionsTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMSaverUpdateImportInstructionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2019, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -70,7 +70,7 @@ public class FXOMSaverUpdateImportInstructionsTest {
     public void testEmptyFXML() throws IOException {
         setupTestCase(FxmlTestInfo.EMPTY);
 
-        assertTrue("fxml is empty", fxomDocument.getFxmlText().isEmpty());
+        assertTrue("fxml is empty", fxomDocument.getFxmlText(false).isEmpty());
     }
 
     @Test

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/fxom/testerFXML.fxml
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/fxom/testerFXML.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.AnchorPane?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
 	<children>
 		<Button layoutX="302.0" layoutY="27.0" mnemonicParsing="false" text="Button" />
 		<ComboBox layoutX="46.0" layoutY="175.0" prefWidth="150.0" />


### PR DESCRIPTION
 LibraryDialogControllerADD LibraryDialog workspace management

  - users can link external jars/fxmls or folders to a workspace that is saved in a xml file inside the userlibrary folder.
  - ability to import/export a workspace
  - command line parsing the workspace: a new switch --ws can be passed to instruct SB to load that workspace (e.g. in Windows launching SceneBuilder.exe --ws="C:\Users\donaldduck\myworkspace.xml")
  - the last workspace imported in SB is persistent, meaning that it behaves like regular jars/folders added to the library as before. The workspace can be altered by using an import or by launching SB with the command line switch --ws
  - workspace is saved in xml format using XStream library (gradle "com.thoughtworks.xstream:xstream:1.4.11.1")

ADD DocumentWindowController refresh library menuitem: using this command the library is refreshed from scatch; this is especially useful when dealing with changing binaries in linked folders

ADD DocumentWindowController when closing the last non-empty window, a new empty window is opened instead: this avoids closing SB when the last window is closed so that a fresh new window appears. This is behaving more like other softwares (see gimp). If the last empty window is closed, SB terminates as usual.

ADD HierarchyTreeViewController, ContentPanelController pressing ESC on hierarchy treeview or on contentPane selects the parent of the current selected control (like other wysiwyg editors..)

FIX LibraryPanelController the library was trying to copy the same jar file on itself when updating filters after the ImportWindowController dialog

FIX LibraryFolderWatcher the watchService was never stopped and remained active forever; multiple overlapping services (each with its own thread) were started everytime a library update was needed (basically, a watchService.close() was missing in the thread runnable..)